### PR TITLE
Fix endDate in ThinkProgressAnalysis

### DIFF
--- a/src/components/think/progress/ThinkProgressAnalysis.js
+++ b/src/components/think/progress/ThinkProgressAnalysis.js
@@ -7,7 +7,7 @@ class ThinkProgressAnalysis {
         this.progressDelta = this.recentProgress;
 
         this.name = this.getName(windowLength);
-        this.endDate = entries[entries.length-1].Date;
+        this.endDate = entries[entries.length-1].Created;
 
         let latest = this.getLastEntry(entries);
         this.completed = this.getCompleted(latest);


### PR DESCRIPTION
## Summary
- use `Created` field instead of `Date` for `endDate` in `ThinkProgressAnalysis`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*