### PR TITLE
Add window unit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ function App() {
 export default App;
 ```
 
+You can also analyze progress programmatically. The `ThinkProgressAnalysis` class
+accepts a window length and units. Supported units are `days`, `weeks`,
+`months` and `years`.
+
+```
+import { ThinkProgressAnalysis } from "./think/progress/ThinkProgressAnalysis";
+
+// Measure progress over the last week
+const analysis = new ThinkProgressAnalysis(dataset.entries, 1, "weeks");
+console.log(analysis.recentProgress);
+```
+
 
 
 

--- a/src/components/think/progress/ThinkProgress.js
+++ b/src/components/think/progress/ThinkProgress.js
@@ -17,9 +17,16 @@ function daysSinceStart(dataset) {
 }
 
 const DAILY_WINDOW = 1;
-const WEEKLY_WINDOW = 7;
-const MONTHLY_WINDOW = 30;
-const YEARLY_WINDOW = 365;
+const WEEKLY_WINDOW = 1;
+const MONTHLY_WINDOW = 1;
+const YEARLY_WINDOW = 1;
+
+const UNIT_TO_DAYS = {
+    "days": 1,
+    "weeks": 7,
+    "months": 30,
+    "years": 365
+};
 
 
 class ThinkProgress extends React.Component {
@@ -32,17 +39,19 @@ class ThinkProgress extends React.Component {
         // length we don't give an estimate. We also don't try if we don't have
         // any data.
         let numDaysSinceStart = daysSinceStart(dataset);
-        let windowLengthsToAnalyze = [
-            numDaysSinceStart,
-            DAILY_WINDOW,
-            WEEKLY_WINDOW,
-            MONTHLY_WINDOW,
-            YEARLY_WINDOW
+        let windowsToAnalyze = [
+            {length: numDaysSinceStart, units: "days"},
+            {length: DAILY_WINDOW, units: "days"},
+            {length: WEEKLY_WINDOW, units: "weeks"},
+            {length: MONTHLY_WINDOW, units: "months"},
+            {length: YEARLY_WINDOW, units: "years"}
         ].filter(
-            (windowLength) => !dataset.isEmpty() && windowLength <= numDaysSinceStart
+            (window) =>
+                !dataset.isEmpty() &&
+                UNIT_TO_DAYS[window.units] * window.length <= numDaysSinceStart
         );
-        const analyses = windowLengthsToAnalyze.map(
-            (windowLength) => new ThinkProgressAnalysis(dataset.entries, windowLength, "days")
+        const analyses = windowsToAnalyze.map(
+            (window) => new ThinkProgressAnalysis(dataset.entries, window.length, window.units)
         );
 
         const extrapolations = analyses.map((analysis) => new ThinkProgressExtrapolation(

--- a/src/components/think/progress/ThinkProgressAnalysis.js
+++ b/src/components/think/progress/ThinkProgressAnalysis.js
@@ -46,15 +46,28 @@ class ThinkProgressAnalysis {
 
     }
 
-    // Returns [windowStart, windowEnd] given a windowLength.
+    // Returns [windowStart, windowEnd] given a windowLength and units.
     makeWindow(windowLength, windowUnits) {
-        windowUnits = "days";
-        if (windowUnits === "days") {
-            let currentDate = new Date();
-            let nDaysAgo = new Date();
-            nDaysAgo.setDate(currentDate.getDate() - windowLength);
-            return [nDaysAgo, currentDate];
+        const currentDate = new Date();
+        const startDate = new Date(currentDate);
+
+        switch (windowUnits) {
+            case "weeks":
+                startDate.setDate(currentDate.getDate() - (windowLength * 7));
+                break;
+            case "months":
+                startDate.setMonth(currentDate.getMonth() - windowLength);
+                break;
+            case "years":
+                startDate.setFullYear(currentDate.getFullYear() - windowLength);
+                break;
+            case "days":
+            default:
+                startDate.setDate(currentDate.getDate() - windowLength);
+                break;
         }
+
+        return [startDate, currentDate];
     }
 
     // A function which calculates the percentage of work which has been completed

--- a/src/components/think/progress/ThinksProgressAnalysis.test.js
+++ b/src/components/think/progress/ThinksProgressAnalysis.test.js
@@ -69,3 +69,32 @@ it('test date fetch', () => {
     let actualName = analysis.getName(10);
     expect(actualName).toBe("last 10 days");
 });
+
+it('makeWindow honors day units', () => {
+    let analysis = new ThinkProgressAnalysis([], 1, "days");
+    let [start, end] = analysis.makeWindow(3, "days");
+    let diff = Math.round((end - start) / (1000 * 60 * 60 * 24));
+    expect(diff).toBe(3);
+});
+
+it('makeWindow honors week units', () => {
+    let analysis = new ThinkProgressAnalysis([], 1, "days");
+    let [start, end] = analysis.makeWindow(2, "weeks");
+    let diff = Math.round((end - start) / (1000 * 60 * 60 * 24));
+    expect(diff).toBe(14);
+});
+
+it('makeWindow honors month units', () => {
+    let analysis = new ThinkProgressAnalysis([], 1, "days");
+    let [start, end] = analysis.makeWindow(1, "months");
+    // approximate month length 30 days as used in implementation
+    let diff = Math.round((end - start) / (1000 * 60 * 60 * 24));
+    expect(diff).toBe(30);
+});
+
+it('makeWindow honors year units', () => {
+    let analysis = new ThinkProgressAnalysis([], 1, "days");
+    let [start, end] = analysis.makeWindow(1, "years");
+    let diff = Math.round((end - start) / (1000 * 60 * 60 * 24));
+    expect(diff).toBe(365);
+});


### PR DESCRIPTION
## Summary
- support new `days`, `weeks`, `months`, and `years` units for analysis windows
- apply the new units when generating analyses
- test makeWindow for multiple unit types
- document window unit usage in README

## Testing
- `yarn test --watchAll=false` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*